### PR TITLE
Added ThreadNameCallable and ThreadNameRunnable

### DIFF
--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadNameCallable.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadNameCallable.java
@@ -14,11 +14,11 @@ public class ThreadNameCallable<V> implements Callable<V> {
 
     public ThreadNameCallable(String threadName, Callable<V> callable) {
         if (threadName == null) {
-            throw new NullPointerException("name cannot be null");
+            throw new IllegalArgumentException("name cannot be null");
         }
 
         if (callable == null) {
-            throw new NullPointerException("callable cannot be null");
+            throw new IllegalArgumentException("callable cannot be null");
         }
 
         this.threadName = threadName;

--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadNameCallable.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadNameCallable.java
@@ -1,0 +1,40 @@
+package io.github.thunkware.vt.bridge;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Class to implement a NamedCallable that sets
+ * the thread name, executes the Callable, then
+ * resets the thread name
+ */
+public class ThreadNameCallable<V> implements Callable<V> {
+
+    private final String threadName;
+    private final Callable<V> callable;
+
+    public ThreadNameCallable(String threadName, Callable<V> callable) {
+        if (threadName == null) {
+            throw new NullPointerException("name cannot be null");
+        }
+
+        if (callable == null) {
+            throw new NullPointerException("callable cannot be null");
+        }
+
+        this.threadName = threadName;
+        this.callable = callable;
+    }
+
+    @Override
+    public V call() throws Exception {
+        Thread currentThread = Thread.currentThread();
+        String originalThreadName = currentThread.getName();
+
+        try {
+            currentThread.setName(threadName);
+            return callable.call();
+        } finally {
+            currentThread.setName(originalThreadName);
+        }
+    }
+}

--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadNameCallable.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadNameCallable.java
@@ -3,7 +3,7 @@ package io.github.thunkware.vt.bridge;
 import java.util.concurrent.Callable;
 
 /**
- * Class to implement a NamedCallable that sets
+ * Convenience callable wrapper that sets
  * the thread name, executes the Callable, then
  * resets the thread name
  */
@@ -12,6 +12,12 @@ public class ThreadNameCallable<V> implements Callable<V> {
     private final String threadName;
     private final Callable<V> callable;
 
+    /**
+     * Constructor
+     *
+     * @param threadName the thread name
+     * @param callable the Callable
+     */
     public ThreadNameCallable(String threadName, Callable<V> callable) {
         if (threadName == null) {
             throw new IllegalArgumentException("threadName cannot be null");

--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadNameCallable.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadNameCallable.java
@@ -14,7 +14,7 @@ public class ThreadNameCallable<V> implements Callable<V> {
 
     public ThreadNameCallable(String threadName, Callable<V> callable) {
         if (threadName == null) {
-            throw new IllegalArgumentException("name cannot be null");
+            throw new IllegalArgumentException("threadName cannot be null");
         }
 
         if (callable == null) {

--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadNameRunnable.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadNameRunnable.java
@@ -1,7 +1,7 @@
 package io.github.thunkware.vt.bridge;
 
 /**
- * Class to implement a NamedRunnable that sets
+ * Convenience runnable wrapper that sets
  * the thread name, executes the Runnable, then
  * resets the thread name
  */

--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadNameRunnable.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadNameRunnable.java
@@ -18,7 +18,7 @@ public class ThreadNameRunnable implements Runnable {
      */
     public ThreadNameRunnable(String threadName, Runnable task) {
         if (threadName == null) {
-            throw new IllegalArgumentException("name cannot be null");
+            throw new IllegalArgumentException("threadName cannot be null");
         }
 
         if (task == null) {

--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadNameRunnable.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadNameRunnable.java
@@ -1,0 +1,44 @@
+package io.github.thunkware.vt.bridge;
+
+/**
+ * Class to implement a NamedRunnable that sets
+ * the thread name, executes the Runnable, then
+ * resets the thread name
+ */
+public class ThreadNameRunnable implements Runnable {
+
+    private final String threadName;
+    private final Runnable task;
+
+    /**
+     * Constructor
+     *
+     * @param threadName the thread name
+     * @param task the Runnable
+     */
+    public ThreadNameRunnable(String threadName, Runnable task) {
+        if (threadName == null) {
+            throw new NullPointerException("name cannot be null");
+        }
+
+        if (task == null) {
+            throw new NullPointerException("task cannot be null");
+        }
+
+        this.threadName = threadName;
+        this.task = task;
+    }
+
+    @Override
+    public void run() {
+        Thread currentThread = Thread.currentThread();
+        String originalThreadName = currentThread.getName();
+
+        try {
+            currentThread.setName(threadName);
+            task.run();
+        } finally {
+            currentThread.setName(originalThreadName);
+        }
+    }
+}

--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadNameRunnable.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadNameRunnable.java
@@ -18,11 +18,11 @@ public class ThreadNameRunnable implements Runnable {
      */
     public ThreadNameRunnable(String threadName, Runnable task) {
         if (threadName == null) {
-            throw new NullPointerException("name cannot be null");
+            throw new IllegalArgumentException("name cannot be null");
         }
 
         if (task == null) {
-            throw new NullPointerException("task cannot be null");
+            throw new IllegalArgumentException("task cannot be null");
         }
 
         this.threadName = threadName;

--- a/src/test/java/io/github/thunkware/vt/bridge/ThreadNameCallableTest.java
+++ b/src/test/java/io/github/thunkware/vt/bridge/ThreadNameCallableTest.java
@@ -1,0 +1,51 @@
+package io.github.thunkware.vt.bridge;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class ThreadNameCallableTest {
+
+    private final String[] validThreadNames = new String[] {
+            "",
+            " ",
+            UUID.randomUUID().toString()
+    };
+
+    @Test
+    public void testValidThreadNames() throws Exception {
+        Thread thread = Thread.currentThread();
+        String originalThreadName = thread.getName();
+
+        for (String validThreadName : validThreadNames) {
+            String uuid = UUID.randomUUID().toString();
+            String result = new ThreadNameCallable<>(
+                    validThreadName,
+                    () -> {
+                        String threadName = Thread.currentThread().getName();
+                        assertThat(threadName).isNotNull();
+                        assertThat(threadName).isEqualTo(validThreadName);
+                        return uuid;
+                    })
+                    .call();
+
+            assertThat(result).isEqualTo(uuid);
+            assertThat(thread.getName()).isEqualTo(originalThreadName);
+        }
+    }
+
+    @Test
+    public void testInvalidArguments() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new ThreadNameCallable<Void>("test", null));
+
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new ThreadNameCallable<>(null, () -> "string"));
+
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new ThreadNameCallable<Void>(null, null));
+    }
+}

--- a/src/test/java/io/github/thunkware/vt/bridge/ThreadNameCallableTest.java
+++ b/src/test/java/io/github/thunkware/vt/bridge/ThreadNameCallableTest.java
@@ -39,13 +39,13 @@ public class ThreadNameCallableTest {
 
     @Test
     public void testInvalidArguments() {
-        assertThatExceptionOfType(NullPointerException.class)
+        assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new ThreadNameCallable<Void>("test", null));
 
-        assertThatExceptionOfType(NullPointerException.class)
+        assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new ThreadNameCallable<>(null, () -> "string"));
 
-        assertThatExceptionOfType(NullPointerException.class)
+        assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new ThreadNameCallable<Void>(null, null));
     }
 }

--- a/src/test/java/io/github/thunkware/vt/bridge/ThreadNameRunnableTest.java
+++ b/src/test/java/io/github/thunkware/vt/bridge/ThreadNameRunnableTest.java
@@ -35,13 +35,13 @@ public class ThreadNameRunnableTest {
 
     @Test
     public void testInvalidArguments() {
-        assertThatExceptionOfType(NullPointerException.class)
+        assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new ThreadNameRunnable("test", null));
 
-        assertThatExceptionOfType(NullPointerException.class)
+        assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new ThreadNameRunnable(null, () -> {}));
 
-        assertThatExceptionOfType(NullPointerException.class)
+        assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new ThreadNameRunnable(null, null));
     }
 }

--- a/src/test/java/io/github/thunkware/vt/bridge/ThreadNameRunnableTest.java
+++ b/src/test/java/io/github/thunkware/vt/bridge/ThreadNameRunnableTest.java
@@ -1,0 +1,47 @@
+package io.github.thunkware.vt.bridge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class ThreadNameRunnableTest {
+
+    private final String[] validThreadNames = new String[] {
+            "",
+            " ",
+            UUID.randomUUID().toString()
+    };
+
+    @Test
+    public void testValidThreadNames() {
+        Thread thread = Thread.currentThread();
+        String originalThreadName = thread.getName();
+
+        for (String validThreadName : validThreadNames) {
+            new ThreadNameRunnable(
+                    validThreadName,
+                    () -> {
+                        String threadName = Thread.currentThread().getName();
+                        assertThat(threadName).isNotNull();
+                        assertThat(threadName).isEqualTo(validThreadName);
+                    })
+                    .run();
+
+            assertThat(thread.getName()).isEqualTo(originalThreadName);
+        }
+    }
+
+    @Test
+    public void testInvalidArguments() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new ThreadNameRunnable("test", null));
+
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new ThreadNameRunnable(null, () -> {}));
+
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new ThreadNameRunnable(null, null));
+    }
+}


### PR DESCRIPTION
**Summary**

Added `ThreadNameCallable` and `ThreadNameRunnable` for scenarios when code needs to set the thread name during the execution of the `Callable` or `Runnable`, for correlation/logging purposes, but wants to revert the thread name to the original version after execution.

**Example Scenario**

- The current thread name is `carrierThread`
- The thread name needs to reflect the work being performed for correlation/logging purposes
  - The thread name needs to be `carrierThread/task1` when executing task 1
  - The thread name needs to be `carrierThread/task2` when executing task 2

**Example Code**

```java
String threadName = Thread.currentThread().getName();
ExecutorService executorService = ExecutorTool.newVirtualThreadPerTaskExecutor();

executorService.submit(
    new NamedRunnable(
        threadName + "/customRunnable1", new CustomRunnable1());

executorService.submit(
    new NamedRunnable(
        threadName + "/customRunnable2", new CustomRunnable2());
```
