### PR TITLE
add fluent api for creating objects conditional on virtual threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Thread thread = ThreadTool.hasVirtualThreads()
     ? ThreadTool.unstartedVirtualThread(myRunnable)
     : new Thread(myRunnable);
 ```
+
+If you prefer a more fluent api, you can write:
+```java
+ExecutorService executor = ExecutorTool.ifVirtualThreads(ExecutorTool::newVirtualThreadPerTaskExecutor)
+        .orElseGet(Executors::newCachedThreadPool);
+
+Thread thread = ThreadTool.ifVirtualThreads(() -> ThreadTool.unstartedVirtualThread(myRunnable))
+        .orElseGet(() -> new Thread(myRunnable));
+```
+
 <br>
 Of course, it's dangerous to blindly create excessive number of (platform) threads in  Java8+/preJava21 without checking if virtual threads are available:
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,22 +25,24 @@
         <gpg.skip>true</gpg.skip>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss z</maven.build.timestamp.format>
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
-        <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
-        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>3.2.2</maven-failsafe-plugin.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
+        <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
+        <surefire-failsafe-option>-Dfoo=bar</surefire-failsafe-option>
 
         <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
 
         <!-- Dependency versions -->
         <assertj-core.version>3.19.0</assertj-core.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
+        <mockito.version>4.11.0</mockito.version>
     </properties>
 
     <licenses>
@@ -99,6 +101,20 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -143,7 +159,7 @@
                 <configuration>
                     <workingDirectory>${project.build.directory}</workingDirectory>
                     <classesDirectory>${project.build.outputDirectory}</classesDirectory>
-                    <argLine>-Xmx1024m -Xms128m ${argLine}</argLine>
+                    <argLine>-Xmx1024m -Xms128m ${surefire-failsafe-option} @{argLine}</argLine>
                     <runOrder>alphabetical</runOrder>
                 </configuration>
                 <executions>
@@ -163,7 +179,7 @@
                 <configuration>
                     <workingDirectory>${project.build.directory}</workingDirectory>
                     <classesDirectory>${project.build.outputDirectory}</classesDirectory>
-                    <argLine>-Xmx1024m -Xms128m ${argLine}</argLine>
+                    <argLine>-Xmx1024m -Xms128m ${surefire-failsafe-option} @{argLine}</argLine>
                     <runOrder>alphabetical</runOrder>
                     <!-- https://issues.apache.org/jira/browse/SUREFIRE-1731 -->
                     <!-- Unable to test Multi Release Jar with surefire or failsafe -->
@@ -307,6 +323,11 @@
             <activation>
                 <jdk>[21,)</jdk>
             </activation>
+
+            <properties>
+                <surefire-failsafe-option>-XX:+EnableDynamicAgentLoading</surefire-failsafe-option>
+            </properties>
+
 
             <build>
                 <plugins>

--- a/src/main/java/io/github/thunkware/vt/bridge/ConditionalBuilder.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ConditionalBuilder.java
@@ -1,0 +1,32 @@
+package io.github.thunkware.vt.bridge;
+
+import java.util.function.Supplier;
+
+/**
+ * Builder for creating threads, executors or objects conditional on virtual threads
+ */
+public class ConditionalBuilder<T> {
+
+    private boolean condition;
+    private Supplier<T> positiveSupplier;
+
+    public static <T> ConditionalBuilder<T> conditionalOn(boolean condition) {
+        return new ConditionalBuilder<>(condition);
+    }
+
+    ConditionalBuilder(boolean condition) {
+        this.condition = condition;
+    }
+
+    public ConditionalBuilder<T> ifTrue(Supplier<T> positiveSupplier) {
+        Supplier<T> exceptionSupplier = () -> {
+            throw new IllegalStateException();
+        };
+        this.positiveSupplier = condition ? positiveSupplier : exceptionSupplier;
+        return this;
+    }
+
+    public T orElseGet(Supplier<T> negativeSupplier) {
+        return condition ? positiveSupplier.get() : negativeSupplier.get();
+    }
+}

--- a/src/main/java/io/github/thunkware/vt/bridge/ExecutorTool.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ExecutorTool.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
+import java.util.function.Supplier;
 
 import static io.github.thunkware.vt.bridge.ThreadProviderFactory.getThreadProvider;
 
@@ -19,7 +20,37 @@ public class ExecutorTool {
      * @return true if the JVM supports virtual threads
      */
     public static boolean hasVirtualThreads() {
-        return getThreadProvider().hasVirtualThreads();
+        return ThreadTool.hasVirtualThreads();
+    }
+
+    /**
+     * On Java 8+, returns false
+     * On Java 24+, returns true
+     *
+     * @return true if the JVM supports virtual threads that can synchronize without pinning
+     */
+    public static boolean hasSafeVirtualThreads() {
+        return ThreadTool.hasSafeVirtualThreads();
+    }
+
+    /**
+     * Creates a builder conditional on {@link #hasVirtualThreads}
+     * @param positiveSupplier supplier to be invoked if {@link #hasVirtualThreads()} is true
+     * @return ConditionalBuilder
+     * @param <T> any
+     */
+    public static <T> ConditionalBuilder<T> ifVirtualThreads(Supplier<T> positiveSupplier) {
+        return ThreadTool.ifVirtualThreads(positiveSupplier);
+    }
+
+    /**
+     * Creates a builder conditional on {@link #hasSafeVirtualThreads}
+     * @param positiveSupplier supplier to be invoked if {@link #hasSafeVirtualThreads()} is true
+     * @return ConditionalBuilder
+     * @param <T> any
+     */
+    public static <T> ConditionalBuilder<T> ifSafeVirtualThreads(Supplier<T> positiveSupplier) {
+        return ThreadTool.ifSafeVirtualThreads(positiveSupplier);
     }
 
     /**

--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadTool.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadTool.java
@@ -3,6 +3,7 @@ package io.github.thunkware.vt.bridge;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static io.github.thunkware.vt.bridge.ThreadFeature.INHERIT_INHERITABLE_THREAD_LOCALS;
 import static io.github.thunkware.vt.bridge.ThreadProvider.getThreadProvider;
@@ -39,6 +40,28 @@ public class ThreadTool {
      */
     public static boolean hasSafeVirtualThreads() {
         return getThreadProvider().hasSafeVirtualThreads();
+    }
+
+    /**
+     * Creates a builder conditional on {@link #hasVirtualThreads}
+     * @param positiveSupplier supplier to be invoked if {@link #hasVirtualThreads()} is true
+     * @return ConditionalBuilder
+     * @param <T> any
+     */
+    public static <T> ConditionalBuilder<T> ifVirtualThreads(Supplier<T> positiveSupplier) {
+        return ConditionalBuilder.<T>conditionalOn(hasVirtualThreads())
+                .ifTrue(positiveSupplier);
+    }
+
+    /**
+     * Creates a builder conditional on {@link #hasSafeVirtualThreads}
+     * @param positiveSupplier supplier to be invoked if {@link #hasSafeVirtualThreads()} is true
+     * @return ConditionalBuilder
+     * @param <T> any
+     */
+    public static <T> ConditionalBuilder<T> ifSafeVirtualThreads(Supplier<T> positiveSupplier) {
+        return ConditionalBuilder.<T>conditionalOn(hasSafeVirtualThreads())
+                                 .ifTrue(positiveSupplier);
     }
 
     /**

--- a/src/test/java/io/github/thunkware/vt/bridge/ConditionalBuilderTest.java
+++ b/src/test/java/io/github/thunkware/vt/bridge/ConditionalBuilderTest.java
@@ -1,0 +1,38 @@
+package io.github.thunkware.vt.bridge;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+class ConditionalBuilderTest {
+
+    @Test
+    void conditionalOnSafeVirtualThreads() {
+        try (final MockedStatic<ThreadTool> mocked = mockStatic(ThreadTool.class)) {
+            mocked.when(() -> ThreadTool.ifSafeVirtualThreads(any()))
+                  .thenCallRealMethod();
+            mocked.when(ThreadTool::hasSafeVirtualThreads)
+                  .thenReturn(true);
+
+            final int result = ThreadTool.ifSafeVirtualThreads(() -> 1)
+                                         .orElseGet(() -> 2);
+            assertThat(result).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void conditionalOnVirtualThreads() {
+        try (final MockedStatic<ThreadTool> mocked = mockStatic(ThreadTool.class)) {
+            mocked.when(() -> ExecutorTool.ifVirtualThreads(any()))
+                  .thenCallRealMethod();
+
+            final int result = ExecutorTool.ifVirtualThreads(() -> 1)
+                                           .orElseGet(() -> 2);
+            assertThat(result).isEqualTo(2);
+        }
+    }
+
+}


### PR DESCRIPTION
fixes issue #35:

As an alternative to if-else code, add a fluent api:

```java
// before
ExecutorService executor = ExecutorTool.hasVirtualThreads()
    ? ExecutorTool.newVirtualThreadPerTaskExecutor()
    : Executors.newCachedThreadPool();

// after
ExecutorService executor = ExecutorTool.ifVirtualThreads(ExecutorTool::newVirtualThreadPerTaskExecutor)
    .orElseGet(Executors::newCachedThreadPool);
```