### PR TITLE
add ExecutorTool.newVirtualThreadPerTaskExecutor(threadFactory)

### DIFF
--- a/src/main/java/io/github/thunkware/vt/bridge/ExecutorTool.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ExecutorTool.java
@@ -1,6 +1,7 @@
 package io.github.thunkware.vt.bridge;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
@@ -71,7 +72,7 @@ public class ExecutorTool {
     }
 
     /**
-     * Creates an Executor that starts a new virtual Thread on Java 21 + (or new platform thread on Java 8+) for each task.
+     * Creates an Executor that starts a new virtual Thread on Java 21+ (or new platform thread on Java 8+) for each task.
      * The number of threads created by the Executor is unbounded.
      *
      * <p> This method is equivalent to invoking
@@ -85,7 +86,7 @@ public class ExecutorTool {
     }
 
     /**
-     * Creates an Executor that starts a new virtual Thread on Java 21 + (or new platform thread on Java 8+) for each task.
+     * Creates an Executor that starts a new virtual Thread on Java 21+ (or new platform thread on Java 8+) for each task.
      * The number of threads created by the Executor is unbounded.
      *
      * <p> This method is equivalent to invoking
@@ -96,7 +97,20 @@ public class ExecutorTool {
      * @return a new executor that creates a new virtual Thread for each task
      */
     public static ExecutorService newVirtualThreadPerTaskExecutor(ThreadCustomizer threadCustomizer) {
-        return getThreadProvider().newVirtualThreadPerTaskExecutor(threadCustomizer);
+        return getThreadProvider().newVirtualThreadPerTaskExecutor(threadCustomizer, null);
+    }
+
+    /**
+     * Creates an Executor that starts a new virtual Thread on Java 21+ (or new platform thread on Java 8+) for each task.
+     * The number of threads created by the Executor is unbounded.
+     *
+     * @param threadFactory threadFactory to supply thread name, UncaughtExceptionHandler and ContextClassLoader.
+     * @return a new executor that creates a new virtual Thread for each task
+     */
+    public static ExecutorService newVirtualThreadPerTaskExecutor(ThreadFactory threadFactory) {
+        Objects.requireNonNull(threadFactory);
+        ThreadCustomizer threadCustomizer = thread -> {};
+        return getThreadProvider().newVirtualThreadPerTaskExecutor(threadCustomizer, threadFactory);
     }
 
     /**

--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadProvider.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadProvider.java
@@ -111,10 +111,11 @@ public interface ThreadProvider {
      * that creates virtual threads.
      *
      * @param threadCustomizer ThreadCustomizer to customize new unstarted threads
+     * @param threadFactory ThreadFactory. can be null
      * @return a new executor that creates a new virtual Thread for each task
      */
     @ConfigFeature(feature = NEW_VIRTUAL_THREAD_PER_TASK_EXECUTOR)
-    ExecutorService newVirtualThreadPerTaskExecutor(ThreadCustomizer threadCustomizer);
+    ExecutorService newVirtualThreadPerTaskExecutor(ThreadCustomizer threadCustomizer, ThreadFactory threadFactory);
 
     /**
      * Returns a builder for creating a platform {@code Thread} or {@code ThreadFactory}

--- a/src/main/java/io/github/thunkware/vt/bridge/ThreadProvider8.java
+++ b/src/main/java/io/github/thunkware/vt/bridge/ThreadProvider8.java
@@ -80,10 +80,11 @@ final class ThreadProvider8 implements ThreadProvider {
     }
 
     @Override
-    public ExecutorService newVirtualThreadPerTaskExecutor(ThreadCustomizer threadCustomizer) {
+    public ExecutorService newVirtualThreadPerTaskExecutor(ThreadCustomizer threadCustomizer, ThreadFactory threadFactory) {
         config.enforceCompatibilityPolicy(NEW_VIRTUAL_THREAD_PER_TASK_EXECUTOR);
 
-        return newThreadPerTaskExecutor(threadCustomizer.asThreadFactory(this::unstartedVirtualThread));
+        ThreadFactory actualFactory = threadFactory == null ? this::unstartedVirtualThread : threadFactory;
+        return newThreadPerTaskExecutor(threadCustomizer.asThreadFactory(actualFactory));
     }
 
     @Override

--- a/src/main/java21/io/github/thunkware/vt/bridge/ThreadProvider21.java
+++ b/src/main/java21/io/github/thunkware/vt/bridge/ThreadProvider21.java
@@ -40,11 +40,17 @@ final class ThreadProvider21 implements ThreadProvider {
 
     @Override
     public Thread unstartedVirtualThread(Runnable task) {
-        return unstartedVirtualThread(task, config.getThreadCustomizer());
+        return unstartedVirtualThread(task, config.getThreadCustomizer(), null);
     }
 
-    private Thread unstartedVirtualThread(Runnable task, ThreadCustomizer threadCustomizer) {
+    private Thread unstartedVirtualThread(Runnable task, ThreadCustomizer threadCustomizer, ThreadFactory threadFactory) {
         Thread thread = Thread.ofVirtual().unstarted(task);
+        if (threadFactory != null) {
+            Thread sample = threadFactory.newThread(task);
+            thread.setName(sample.getName());
+            thread.setUncaughtExceptionHandler(sample.getUncaughtExceptionHandler());
+            thread.setContextClassLoader(sample.getContextClassLoader());
+        }
         threadCustomizer.customize(thread);
         return thread;
     }
@@ -61,8 +67,8 @@ final class ThreadProvider21 implements ThreadProvider {
     }
 
     @Override
-    public ExecutorService newVirtualThreadPerTaskExecutor(ThreadCustomizer threadCustomizer) {
-        return newThreadPerTaskExecutor(runnable -> unstartedVirtualThread(runnable, threadCustomizer));
+    public ExecutorService newVirtualThreadPerTaskExecutor(ThreadCustomizer threadCustomizer, ThreadFactory threadFactory) {
+        return newThreadPerTaskExecutor(runnable -> unstartedVirtualThread(runnable, threadCustomizer, threadFactory));
     }
 
     @Override

--- a/src/test/java/io/github/thunkware/vt/bridge/ExecutorTool21Test.java
+++ b/src/test/java/io/github/thunkware/vt/bridge/ExecutorTool21Test.java
@@ -198,6 +198,22 @@ class ExecutorTool21Test {
         }
     }
 
+    @Test
+    void testNewVirtualThreadPerTaskExecutorThreadFactory() {
+        AtomicInteger counter = new AtomicInteger();
+        ThreadFactory threadFactory = runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("my-thread-" + counter.getAndIncrement());
+            return thread;
+        };
+        executor = ExecutorTool.newVirtualThreadPerTaskExecutor(threadFactory);
+        try {
+            verifyThreadNamePrefix(executor);
+        } finally {
+            executor.shutdown();
+        }
+    }
+
     private void verifyThreadNamePrefix(ExecutorService executor) {
         CountDownLatch latch = new CountDownLatch(2);
         Future<?> future1 = executor.submit(() -> {

--- a/src/test/java/io/github/thunkware/vt/bridge/ExecutorTool8Test.java
+++ b/src/test/java/io/github/thunkware/vt/bridge/ExecutorTool8Test.java
@@ -10,8 +10,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.commons.lang3.JavaVersion.JAVA_20;
 import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
@@ -137,6 +139,22 @@ class ExecutorTool8Test {
         } finally {
             ThreadTool.getConfig().setThreadCustomizer(thread -> {
             });
+        }
+    }
+
+    @Test
+    void testNewVirtualThreadPerTaskExecutorThreadFactory() {
+        AtomicInteger counter = new AtomicInteger();
+        ThreadFactory threadFactory = runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("my-thread-" + counter.getAndIncrement());
+            return thread;
+        };
+        ExecutorService executor = ExecutorTool.newVirtualThreadPerTaskExecutor(threadFactory);
+        try {
+            verifyThreadNamePrefix(executor);
+        } finally {
+            executor.shutdown();
         }
     }
 


### PR DESCRIPTION
Add to ExecutorTool:

```java
ExecutorService newVirtualThreadPerTaskExecutor(ThreadFactory threadFactory)
```

useful when refactoring legacy code:
```java
ThreadFactory threadFactory = ...
ExecutorTool.ifSafeVirtualThreads(() -> ExecutorTool.newVirtualThreadPerTaskExecutor(threadFactory))
    .orElseGet(() -> Executors.newCachedThreadTool(threadFactory))
```